### PR TITLE
Add required Algolia branding

### DIFF
--- a/client/src/components/Search/Search.vue
+++ b/client/src/components/Search/Search.vue
@@ -14,6 +14,7 @@
                 </div>
             </li>
         </ul>
+        <span class="w3-right">Searches indexed by Algolia <i class="fab fa-algolia"></i></span>
     </div>
 
 </template>


### PR DESCRIPTION
Looks like we need to use Algolia branding in our search system so we don't get sued or something.